### PR TITLE
Add database seeding to workspace setup

### DIFF
--- a/conductor-setup.sh
+++ b/conductor-setup.sh
@@ -94,6 +94,11 @@ echo "🔧 Running database migrations..."
 php artisan migrate --force --no-interaction --ansi
 echo ""
 
+# Seed database
+echo "🌱 Seeding database..."
+php artisan db:seed --force --no-interaction --ansi
+echo ""
+
 # Build frontend assets
 echo "🎨 Building frontend assets..."
 npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "lucidlog",
+    "name": "san-francisco",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {


### PR DESCRIPTION
## Summary
Automatically seeds the database during workspace creation to ensure the persistent test user is available in all new Conductor workspaces. The test user (test@example.com) will now be created alongside the initial migrations, eliminating the need for manual setup.

## Changes
- Added `php artisan db:seed` step to conductor-setup.sh after migrations
- Updated package-lock.json from workspace creation